### PR TITLE
v2 Max Linking Error 

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -87,6 +87,10 @@ outputs:
     description: "count of created issues"
   closed:
     description: "count of closed issues"
+  create-issue-errors:
+    description: "count of errors encountered during Jira issue creation"
+  link-issue-errors:
+    description: "count of errors encountered during Jira issue linking"
   jql:
     description: "the jql query for new updates"
 runs:

--- a/dist/index.js
+++ b/dist/index.js
@@ -59748,6 +59748,10 @@ async function run() {
         // Set the new error count outputs
         core.setOutput('create-issue-errors', syncResult.createIssueErrors);
         core.setOutput('link-issue-errors', syncResult.linkIssueErrors);
+        // Fail the job if there are any create issue errors or link issue errors
+        if (syncResult.createIssueErrors > 0 || syncResult.linkIssueErrors > 0) {
+            throw new Error(`Job failed due to errors: ${syncResult.createIssueErrors} create issue errors, ${syncResult.linkIssueErrors} link issue errors`);
+        }
     }
     catch (error) {
         core.setFailed(`Sync failed: ${extractErrorMessage(error)}`);

--- a/dist/macfc-security-hub-sync.d.ts
+++ b/dist/macfc-security-hub-sync.d.ts
@@ -39,6 +39,8 @@ export declare class SecurityHubJiraSync {
     private jiraLinkDirection?;
     jiraLabelsConfig?: LabelConfig[];
     private jiraAddLabels?;
+    private createIssueErrors;
+    private linkIssueErrors;
     private jiraConsolidateTickets?;
     private testFindings;
     constructor(jiraConfig: JiraConfig, securityHubConfig: SecurityHubJiraSyncConfig, autoClose: boolean);
@@ -46,7 +48,11 @@ export declare class SecurityHubJiraSync {
     areSameLists(A: Resource[], B: Resource[]): boolean;
     isAlreadyInNew(finding: SecurityHubFinding, List: SecurityHubFinding[]): boolean;
     isNewFinding(finding: SecurityHubFinding, issues: Issue[]): boolean;
-    sync(): Promise<UpdateForReturn[]>;
+    sync(): Promise<{
+        updatesForReturn: UpdateForReturn[];
+        createIssueErrors: number;
+        linkIssueErrors: number;
+    }>;
     getAWSAccountID(): Promise<string>;
     shouldCloseTicket(ticket: Issue, findings: SecurityHubFinding[]): boolean;
     closeIssuesForResolvedFindings(jiraIssues: Issue[], shFindings: SecurityHubFinding[]): Promise<UpdateForReturn[]>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -267,6 +267,11 @@ async function run(): Promise<void> {
     core.setOutput('create-issue-errors', syncResult.createIssueErrors);
     core.setOutput('link-issue-errors', syncResult.linkIssueErrors);
 
+    // Fail the job if there are any create issue errors or link issue errors
+    if (syncResult.createIssueErrors > 0 || syncResult.linkIssueErrors > 0) {
+      throw new Error(`Job failed due to errors: ${syncResult.createIssueErrors} create issue errors, ${syncResult.linkIssueErrors} link issue errors`);
+    }
+
   } catch (error: unknown) {
     core.setFailed(`Sync failed: ${extractErrorMessage(error)}`)
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -225,7 +225,8 @@ async function run(): Promise<void> {
       securityHubConfig,
       autoClose
     )
-    const resultUpdates = await secHub.sync()
+    const syncResult = await secHub.sync()
+    const resultUpdates = syncResult.updatesForReturn; // Extract the updates array
 
     // Construct the JQL
     const jqlQuery = `issueKey in ( ${resultUpdates
@@ -262,6 +263,10 @@ async function run(): Promise<void> {
       'closed',
       resultUpdates.filter(update => update.action == 'closed').length
     )
+    // Set the new error count outputs
+    core.setOutput('create-issue-errors', syncResult.createIssueErrors);
+    core.setOutput('link-issue-errors', syncResult.linkIssueErrors);
+
   } catch (error: unknown) {
     core.setFailed(`Sync failed: ${extractErrorMessage(error)}`)
   }


### PR DESCRIPTION
Overview-
This PR updates the Security Hub to Jira automation to ensure the GitHub Action fails when Jira issue creation encounters limits or constraints (e.g., the 2000 issue linking limit in Altassian).

Problem-
Previously, if Jira rejected an issue creation due to a constraint (such as the max linking limit), the GitHub Action would fail silently, making it difficult to detect and respond to the issue.

What’s Changed-
Added explicit error handling for Jira issue creation failures.

GitHub Action now throws a failure and stops the workflow when such limits are hit.