### PR TITLE
Due Date Logic PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,9 +589,10 @@ See test-infrastructure/jira-container/README.md for instructions on how to run 
 
 Automatically assigns a due date to newly created Jira issues based on the severity of the Security Hub finding.
 
-When a Jira issue is created, the system checks for a severity label (CRITICAL, HIGH, MEDIUM, MODERATE, or LOW) and calculates the due date by adding a configurable number of days to the current date. The resulting date is formatted as YYYY-MM-DD and added to the duedate field.
+When a Jira issue is created, the system checks for a severity label (CRITICAL, HIGH, MODERATE, or LOW) and calculates the due date by adding a configurable number of days to the current date. 
+The resulting date is formatted as YYYY-MM-DD and added to the duedate field.
 
-Default Due Dates by Severity
+**Default Due Dates by Severity**
 
 You can customize these defaults via GitHub Action inputs or environment variables.
 

--- a/README.md
+++ b/README.md
@@ -603,6 +603,14 @@ You can customize these defaults via GitHub Action inputs or environment variabl
 | Moderate   | `due-date-moderate`  | 90             |
 | Low        | `due-date-low`       | 365            |
 
+**Configuring the Due Date Field**
+
+By default, the due date is set in the standard Jira `duedate` field. However, you can specify a different field (e.g., a custom field) using the `jira-duedate-field` input.
+
+| Input Name           | Default Value | Description                                                                 |
+|----------------------|---------------|-----------------------------------------------------------------------------|
+| `business-duedate` | `duedate`     | The Jira field ID to use for setting the due date (e.g., `customfield_xxxxx`). |
+
 ** Examples of GitHub Action inputs: **
 -  due-date-critical: 3
 -  due-date-high:     6

--- a/README.md
+++ b/README.md
@@ -583,3 +583,27 @@ Result of the custom labeling above the labels on the issues created will be: "p
 ## Local Testing
 
 See test-infrastructure/jira-container/README.md for instructions on how to run against local Jira container
+
+
+## Due Date Automation
+
+Automatically assigns a due date to newly created Jira issues based on the severity of the Security Hub finding.
+
+When a Jira issue is created, the system checks for a severity label (CRITICAL, HIGH, MEDIUM, MODERATE, or LOW) and calculates the due date by adding a configurable number of days to the current date. The resulting date is formatted as YYYY-MM-DD and added to the duedate field.
+
+Default Due Dates by Severity
+
+You can customize these defaults via GitHub Action inputs or environment variables.
+
+| Severity   | Input Name           | Default (Days) |
+|------------|----------------------|----------------|
+| Critical   | `due-date-critical`  | 15             |
+| High       | `due-date-high`      | 30             |
+| Moderate   | `due-date-moderate`  | 90             |
+| Low        | `due-date-low`       | 365            |
+
+** Examples of GitHub Action inputs: **
+-  due-date-critical: 3
+-  due-date-high:     6
+-  due-date-moderate:   9
+-  due-date-low:      12

--- a/README.md
+++ b/README.md
@@ -616,3 +616,19 @@ By default, the due date is set in the standard Jira `duedate` field. However, y
 -  due-date-high:     6
 -  due-date-moderate:   9
 -  due-date-low:      12
+
+## How to Find a Custom Field ID in Jira
+
+1. Access Jira Administration
+ Ensure you're logged in as a Jira Admin.
+ - Go to: Jira Settings → Issues → Custom Fields
+2. Locate the Custom Field
+ - Use the search bar to find the field you're interested in.
+3. Open Field Details
+ - Click the three-dot menu next to the field and select Edit Details.
+4. Find the Field ID
+ - You'll be redirected to a new URL. The custom field ID will appear in the URL, formatted like this:
+
+   `id=<field_id>`
+   
+ - The field name will be:  customfield_<field_id>

--- a/action.yml
+++ b/action.yml
@@ -69,6 +69,10 @@ inputs:
   skip-products:
     description: "comma separated list of product names for those the findings should be skipped"
     required: false
+  jira-duedate-field:
+    description: 'The Jira field ID to use for setting the due date (e.g., duedate, customfield_xxxxx). Defaults to duedate.'
+    required: false
+    default: 'duedate'
   due-date-critical:
       description: 'Number of days within which a Jira issue should be due for critical findings'
       required: false

--- a/action.yml
+++ b/action.yml
@@ -69,6 +69,22 @@ inputs:
   skip-products:
     description: "comma separated list of product names for those the findings should be skipped"
     required: false
+  due-date-critical:
+      description: 'Number of days within which a Jira issue should be due for critical findings'
+      required: false
+      default: '15'
+  due-date-high:
+    description: 'Number of days within which a Jira issue should be due for high findings'
+    required: false
+    default: '30'
+  due-date-moderate:
+    description: 'Number of days within which a Jira issue should be due for moderate findings'
+    required: false
+    default: '90'
+  due-date-low:
+    description: 'Number of days within which a Jira issue should be due for low findings'
+    required: false
+    default: '365'
   jira-labels-config:
     description: "This variable is to specify stringified labels config"
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -59748,6 +59748,11 @@ async function run() {
         core.setOutput('total', resultUpdates.length);
         core.setOutput('created', resultUpdates.filter(update => update.action == 'created').length);
         core.setOutput('closed', resultUpdates.filter(update => update.action == 'closed').length);
+        // log into console also
+        core.info(`Jira URL: ${jiraUrl} \n` +
+            `Total Issues: ${resultUpdates.length} \n` +
+            `Created Issues: ${resultUpdates.filter(update => update.action == 'created').length} \n` +
+            `Closed Issues: ${resultUpdates.filter(update => update.action == 'closed').length}`);
     }
     catch (error) {
         core.setFailed(`Sync failed: ${extractErrorMessage(error)}`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -61084,16 +61084,37 @@ class SecurityHubJiraSync {
         }
         let newIssueInfo;
         try {
-            newIssueInfo = await this.jira.createNewIssue(newIssueData);
+            // Create the Jira issue
+            try {
+                newIssueInfo = await this.jira.createNewIssue(newIssueData);
+            }
+            catch (createError) {
+                // Log the error for visibility
+                const errorMsg = (0, index_1.extractErrorMessage)(createError);
+                console.error(`Error creating Jira issue for finding "${finding.title}": ${errorMsg}`);
+                // Re-throw to potentially fail the action if creation fails
+                throw new Error(`Failed to create Jira issue: ${errorMsg}`);
+            }
+            // Link the issue if a link ID is provided
             const issue_id = this.jiraLinkId;
             if (issue_id) {
                 const linkType = this.jiraLinkType;
                 const linkDirection = this.jiraLinkDirection;
-                await this.jira.linkIssues(newIssueInfo.key, issue_id, linkType, linkDirection);
+                try {
+                    await this.jira.linkIssues(newIssueInfo.key, issue_id, linkType, linkDirection);
+                }
+                catch (linkError) {
+                    const errorMsg = (0, index_1.extractErrorMessage)(linkError);
+                    // Log the error for easier debugging, but don't re-throw
+                    console.error(`Error linking issue ${newIssueInfo.key} to ${issue_id}: ${errorMsg}`);
+                }
             }
         }
         catch (e) {
-            throw new Error(`Error creating Jira issue from finding: ${(0, index_1.extractErrorMessage)(e)}`);
+            // This will catch errors re-thrown from createNewIssue block
+            // Errors from linkIssues are caught and logged above, not re-thrown here.
+            // If createNewIssue failed, newIssueInfo would be undefined, so linking wouldn't be attempted.
+            throw new Error(`Error during Jira issue creation process for finding "${finding.title}": ${(0, index_1.extractErrorMessage)(e)}`);
         }
         return {
             action: 'created',

--- a/dist/libs/jira-lib.d.ts
+++ b/dist/libs/jira-lib.d.ts
@@ -24,6 +24,7 @@ export interface JiraConfig {
     dueDateHigh?: string;
     dueDateModerate?: string;
     dueDateLow?: string;
+    jiraDueDateField?: string;
 }
 export type CustomFields = {
     [key: string]: string;
@@ -48,6 +49,7 @@ interface IssueFields {
         name: string;
     };
     duedate?: string;
+    [key: string]: any;
 }
 export interface NewIssueData {
     fields: IssueFields;
@@ -77,6 +79,7 @@ export declare class Jira {
     private dueDateHigh;
     private dueDateModerate;
     private dueDateLow;
+    private jiraDueDateField;
     constructor(jiraConfig: JiraConfig);
     getCurrentUser(): Promise<any>;
     getIssue(issueId: string): Promise<any>;

--- a/dist/libs/jira-lib.d.ts
+++ b/dist/libs/jira-lib.d.ts
@@ -20,6 +20,10 @@ export interface JiraConfig {
     includeAllProducts: boolean;
     skipProducts?: string;
     jiraLabelsConfig?: string;
+    dueDateCritical?: string;
+    dueDateHigh?: string;
+    dueDateModerate?: string;
+    dueDateLow?: string;
 }
 export type CustomFields = {
     [key: string]: string;
@@ -43,6 +47,7 @@ interface IssueFields {
     assignee?: {
         name: string;
     };
+    duedate?: string;
 }
 export interface NewIssueData {
     fields: IssueFields;
@@ -68,6 +73,10 @@ export declare class Jira {
     private dryRunIssueCounter;
     private jiraLabelsConfig?;
     private jiraWatchers?;
+    private dueDateCritical;
+    private dueDateHigh;
+    private dueDateModerate;
+    private dueDateLow;
     constructor(jiraConfig: JiraConfig);
     getCurrentUser(): Promise<any>;
     getIssue(issueId: string): Promise<any>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -282,6 +282,17 @@ async function run(): Promise<void> {
       'closed',
       resultUpdates.filter(update => update.action == 'closed').length
     )
+    // log into console also
+    core.info(
+      `Jira URL: ${jiraUrl} \n` +
+        `Total Issues: ${resultUpdates.length} \n` +
+        `Created Issues: ${resultUpdates.filter(
+          update => update.action == 'created'
+        ).length} \n` +
+        `Closed Issues: ${resultUpdates.filter(
+          update => update.action == 'closed'
+        ).length}`
+    )
   } catch (error: unknown) {
     core.setFailed(`Sync failed: ${extractErrorMessage(error)}`)
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -183,6 +183,26 @@ async function run(): Promise<void> {
       jiraLabelsConfig: getInputOrEnv(
         'jira-labels-config',
         'JIRA_LABELS_CONFIG'
+      ),
+      dueDateCritical: getDefaultInputOrEnv(
+        'due-date-critical',
+        'DUE_DATE_CRITICAL',
+        '15'
+      ),
+      dueDateHigh: getDefaultInputOrEnv(
+        'due-date-high',
+        'DUE_DATE_HIGH',
+        '30'
+      ),
+      dueDateModerate: getDefaultInputOrEnv(
+        'due-date-moderate',
+        'DUE_DATE_MODERATE',
+        '90'
+      ),
+      dueDateLow: getDefaultInputOrEnv(
+        'due-date-low',
+        'DUE_DATE_LOW',
+        '365'
       )
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -203,6 +203,11 @@ async function run(): Promise<void> {
         'due-date-low',
         'DUE_DATE_LOW',
         '365'
+      ),
+      jiraDueDateField: getDefaultInputOrEnv( // Add the new input reading
+        'jira-duedate-field',
+        'JIRA_DUEDATE_FIELD',
+        'duedate'
       )
     }
 

--- a/src/macfc-security-hub-sync.ts
+++ b/src/macfc-security-hub-sync.ts
@@ -661,22 +661,42 @@ export class SecurityHubJiraSync {
     }
     let newIssueInfo
     try {
-      newIssueInfo = await this.jira.createNewIssue(newIssueData)
+      // Create the Jira issue
+      try {
+        newIssueInfo = await this.jira.createNewIssue(newIssueData)
+      } catch (createError: unknown) {
+        // Log the error for visibility
+        const errorMsg = extractErrorMessage(createError);
+        console.error(`Error creating Jira issue for finding "${finding.title}": ${errorMsg}`);
+        // Re-throw to potentially fail the action if creation fails
+        throw new Error(`Failed to create Jira issue: ${errorMsg}`);
+      }
+
+      // Link the issue if a link ID is provided
       const issue_id = this.jiraLinkId
       if (issue_id) {
         const linkType = this.jiraLinkType
         const linkDirection = this.jiraLinkDirection
-        await this.jira.linkIssues(
-          newIssueInfo.key,
-          issue_id,
-          linkType,
-          linkDirection
-        )
+        try {
+          await this.jira.linkIssues(
+            newIssueInfo.key,
+            issue_id,
+            linkType,
+            linkDirection
+          );
+        } catch (linkError: unknown) {
+          const errorMsg = extractErrorMessage(linkError);
+          // Log the error for easier debugging, but don't re-throw
+          console.error(`Error linking issue ${newIssueInfo.key} to ${issue_id}: ${errorMsg}`);
+        }
       }
     } catch (e: unknown) {
+      // This will catch errors re-thrown from createNewIssue block
+      // Errors from linkIssues are caught and logged above, not re-thrown here.
+      // If createNewIssue failed, newIssueInfo would be undefined, so linking wouldn't be attempted.
       throw new Error(
-        `Error creating Jira issue from finding: ${extractErrorMessage(e)}`
-      )
+        `Error during Jira issue creation process for finding "${finding.title}": ${extractErrorMessage(e)}`
+      );
     }
     return {
       action: 'created',


### PR DESCRIPTION
https://jiraent.cms.gov/browse/CMCSMACD-3329

This Security Hub to Jira automation GitHub Action automatically sets a due date for all Jira issues based on the severity of the Security Hub finding. The following due date logic is implemented as default and have customization ability to change the above dates using the Github Actions workflow file.

Critical findings → Due within 15 days
High findings → Due within 30 days
Moderate findings → Due within 90 days
Low findings → Due within 365 days