### PR TITLE
CVE id due datev2

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,3 +632,7 @@ By default, the due date is set in the standard Jira `duedate` field. However, y
    `id=<field_id>`
    
  - The field name will be:  customfield_<field_id>
+
+This logic now attempts to fetch due dates from the CISA Known Exploited Vulnerabilities (KEV) feed when a CVE ID is present.
+If found, it uses the CISA due date.
+If no CISA due date is found, it falls back to our severity-based default due dates.

--- a/action.yml
+++ b/action.yml
@@ -72,7 +72,7 @@ inputs:
   jira-duedate-field:
     description: 'The Jira field ID to use for setting the due date (e.g., duedate, customfield_xxxxx). Defaults to duedate.'
     required: false
-    default: 'duedate'
+    default: ''
   due-date-critical:
       description: 'Number of days within which a Jira issue should be due for critical findings'
       required: false

--- a/dist/libs/jira-lib.d.ts
+++ b/dist/libs/jira-lib.d.ts
@@ -93,6 +93,10 @@ export declare class Jira {
     static createSearchLabels(identifyingLabels: string[], config: LabelConfig[]): string[];
     createSearchLabels(identifyingLabels: string[], config: LabelConfig[]): string[];
     getAllSecurityHubIssuesInJiraProject(identifyingLabels: string[]): Promise<Issue[]>;
+    /**
+     * Fetches the CISA Known Exploited Vulnerabilities feed and returns the CISA date for a given CVE ID, if found.
+     */
+    private getCisaDueDate;
     createNewIssue(issue: NewIssueData): Promise<Issue>;
     linkIssues(newIssueKey: string, issueID: string, linkType?: string, linkDirection?: string): Promise<void>;
     updateIssueTitleById(issueId: string, updatedIssue: Partial<Issue>): Promise<void>;

--- a/dist/libs/jira-lib.d.ts
+++ b/dist/libs/jira-lib.d.ts
@@ -80,6 +80,7 @@ export declare class Jira {
     private dueDateModerate;
     private dueDateLow;
     private jiraDueDateField;
+    private cisaFeedCache;
     constructor(jiraConfig: JiraConfig);
     getCurrentUser(): Promise<any>;
     getIssue(issueId: string): Promise<any>;
@@ -95,6 +96,7 @@ export declare class Jira {
     getAllSecurityHubIssuesInJiraProject(identifyingLabels: string[]): Promise<Issue[]>;
     /**
      * Fetches the CISA Known Exploited Vulnerabilities feed and returns the CISA date for a given CVE ID, if found.
+     * Implements caching to avoid repeated API calls within a session.
      */
     private getCisaDueDate;
     createNewIssue(issue: NewIssueData): Promise<Issue>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -207,7 +207,7 @@ async function run(): Promise<void> {
       jiraDueDateField: getDefaultInputOrEnv( // Add the new input reading
         'jira-duedate-field',
         'JIRA_DUEDATE_FIELD',
-        'duedate'
+        ''
       )
     }
 


### PR DESCRIPTION
### Summary

This PR updates the Jira ticket creation workflow to support **CVE-based due dates** using the [CISA Known Exploited Vulnerabilities (KEV) catalog](https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json).

### What's New

* When a `CVE-ID` is present in the finding and found in the KEV catalog, the Jira ticket will use the associated `dueDate` from CISA.
* If no matching `CVE-ID` is found, the ticket will fall back to the default SLA:

  * Critical → 15 days
  * High → 30 days
  * Moderate → 90 days
  * Low → 365 days

### Configuration Required

To enable this behavior, the following config must be added to the `jira-labels-config` array:

```json
{
  "labelField": "CVE",
  "labelPrefix": "",
  "labelDelimiter": ""
}
```

