### PR TITLE
replace app token with GITHUB_TOKEN

### DIFF
--- a/.github/workflows/generate-codejson.yml
+++ b/.github/workflows/generate-codejson.yml
@@ -3,6 +3,11 @@ on:
   schedule:
    - cron: "0 0 1 * *" # monthly
 
+permissions:
+  contents: write      # Required for code.json generation and PR creation
+  pull-requests: write # Required to create a PR
+  issues: write        # Required to apply labels to the PR
+
 jobs:
   update-code-json:
     runs-on: ubuntu-latest
@@ -12,15 +17,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Generate token from GitHub App
-        id: create_token
-        uses: tibdex/github-app-token@v2.1.0
-        with:
-          app_id: ${{ secrets.PR_PERMS_APP_ID }}
-          private_key: ${{ secrets.PR_PERMS_APP_SECRET }}
-
       - name: Update code.json
         uses: DSACMS/automated-codejson-generator@v1.0.0
         with:
-          GITHUB_TOKEN: ${{ steps.create_token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: "main"


### PR DESCRIPTION
https://jiraent.cms.gov/browse/CMCSMACD-4313

This PR replaces the GitHub App token authentication with the built-in GITHUB_TOKEN for the code.json generation workflow. The change simplifies authentication by removing the need for custom app secrets and adds explicit workflow permissions.

1. Removes GitHub App token generation step and associated secrets
2. Adds explicit permissions block for contents, pull-requests, and issues
3. Updates the automated-codejson-generator action to use GITHUB_TOKEN instead of the app token

Tested:
This has been tested in the professor-mac repo.