### PR TITLE
Sync main branch updates into v2

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,13 +17,13 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: TypeScript
         source-root: src
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/generate-codejson.yml
+++ b/.github/workflows/generate-codejson.yml
@@ -1,0 +1,26 @@
+name: Generate code.json
+on:
+  schedule:
+   - cron: "0 0 1 * *" # monthly
+
+jobs:
+  update-code-json:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Generate token from GitHub App
+        id: create_token
+        uses: tibdex/github-app-token@v2.1.0
+        with:
+          app_id: ${{ secrets.PR_PERMS_APP_ID }}
+          private_key: ${{ secrets.PR_PERMS_APP_SECRET }}
+
+      - name: Update code.json
+        uses: DSACMS/automated-codejson-generator@v1.1.0
+        with:
+          GITHUB_TOKEN: ${{ steps.create_token.outputs.token }}
+          BRANCH: "main"

--- a/code.json
+++ b/code.json
@@ -1,0 +1,75 @@
+{
+  "name": "mac-fc-security-hub-visibility",
+  "description": "A GitHub action that syncs Security Hub findings with Jira tickets.",
+  "longDescription": "An action that gets all findings from Security Hub and for each finding, creates/updates a Jira ticket if necessary.",
+  "status": "Production",
+  "permissions": {
+    "licenses": [
+      {
+        "name": "None",
+        "URL": "none"
+      }
+    ],
+    "usageType": "governmentWideReuse",
+    "exemptionText": ""
+  },
+  "organization": "Centers for Medicare & Medicaid Services",
+  "repositoryURL": "https://github.com/Enterprise-CMCS/mac-fc-security-hub-visibility",
+  "projectURL": "",
+  "repositoryHost": "github.com/CMS-Enterprise",
+  "repositoryVisibility": "public",
+  "vcs": "git",
+  "laborHours": 0,
+  "reuseFrequency": {
+    "forks": 0
+  },
+  "platforms": [
+    "linux"
+  ],
+  "categories": [
+    "compliance-management",
+    "it-security"
+  ],
+  "softwareType": "standalone/backend",
+  "languages": [
+    "JavaScript"
+  ],
+  "maintenance": "contract",
+  "contractNumber": "47QTCA21D00AC",
+  "date": {
+    "created": "",
+    "lastModified": "",
+    "metaDataLastUpdated": ""
+  },
+  "tags": [
+    "sechub",
+    "compliance",
+    "governance",
+    "security-sync"
+  ],
+  "contact": {
+    "email": "cms-macfc@corbalt.com",
+    "name": "Corbalt"
+  },
+  "feedbackMechanisms": [
+    "https://github.com/Enterprise-CMCS/mac-fc-security-hub-visibility/issues"
+  ],
+  "localisation": false,
+  "repositoryType": "tools",
+  "userInput": false,
+  "fismaLevel": "Moderate",
+  "group": "CMCS/DSG",
+  "projects": [
+    "Security Sync"
+  ],
+  "upstream": [
+    "https://github.com/Enterprise-CMCS/mac-fc-security-hub-visibility/network/dependencies"
+  ],
+  "subsetInHealthcare": [
+    "Medicaid"
+  ],
+  "userType": [
+    "Government"
+  ],
+  "maturityModelTier": 2
+}


### PR DESCRIPTION
This PR brings into the v2 branch the items that were previously added only to main, so we can safely set v2 as the default branch and archive main.

**Included changes:**
	•	Added code.json and generate-codejson.yml → required per CMS policy for the default branch
	•	Updated codeql-analysis.yml 